### PR TITLE
fix(#91): update to new dalamud RenderDrawDataInternal

### DIFF
--- a/FfxivVr/game/DalamudRenderer.cs
+++ b/FfxivVr/game/DalamudRenderer.cs
@@ -18,25 +18,35 @@ public unsafe class DalamudRenderer
     public void Initialize()
     {
         var interfaceManager = Service<InterfaceManager>.GetNullable() ?? throw new Exception("Failed to get InterfaceManager");
-        var backend = interfaceManager.Backend as Dx11Win32Backend ?? throw new Exception("Failed to get Dx11Win32Backend"); ;
+        var backend = interfaceManager.Backend as Dx11Win32Backend ?? throw new Exception("Failed to get Dx11Win32Backend");
         renderer = backend.Renderer as Dx11Renderer ?? throw new Exception("Failed to get Dx11Renderer");
 
         var assembly = Assembly.GetAssembly(typeof(Dx11Renderer)) ?? throw new Exception("Failed to get Assembly");
         var type = assembly.GetType("Dalamud.Interface.ImGuiBackend.Renderers.Dx11Renderer") ?? throw new Exception("Failed to get Dx11Renderer type");
-        renderDrawDataInternalMethod = type.GetRuntimeMethods().Where(m => m.Name == "RenderDrawDataInternal").First();
+
+        var methods = type.GetRuntimeMethods().Where(m => m.Name == "RenderDrawDataInternal").ToList();
+
+        renderDrawDataInternalMethod = methods.First();
     }
 
-    internal void Render(ID3D11RenderTargetView* renderTargetView)
+    internal void Render(ID3D11Texture2D* renderTargetTexture, ID3D11RenderTargetView* renderTargetView)
     {
-        RenderDrawDataInternal(renderTargetView, ImGui.GetDrawData(), false);
+        // Pass the texture down into the internal method
+        RenderDrawDataInternal(renderTargetTexture, renderTargetView, ImGui.GetDrawData(), false);
     }
 
     private void RenderDrawDataInternal(
-       ID3D11RenderTargetView* renderTargetView,
-       ImDrawDataPtr drawData,
-       bool clearRenderTarget)
+        ID3D11Texture2D* renderTargetTexture,
+        ID3D11RenderTargetView* renderTargetView,
+        ImDrawDataPtr drawData,
+        bool clearRenderTarget)
     {
-        renderDrawDataInternalMethod?.Invoke(renderer, [(IntPtr)renderTargetView, drawData, clearRenderTarget]);
+        renderDrawDataInternalMethod?.Invoke(renderer, [
+            (IntPtr)renderTargetTexture,
+            (IntPtr)renderTargetView,
+            drawData,
+            clearRenderTarget
+        ]);
     }
 
 }

--- a/FfxivVr/vr/Renderer.cs
+++ b/FfxivVr/vr/Renderer.cs
@@ -190,7 +190,10 @@ public unsafe class Renderer(
         resources.SetUIBlendState(context);
         var color = new float[] { 0f, 0f, 0f, 0f };
         context->ClearRenderTargetView(resources.DalamudRenderTarget.RenderTargetView, ref color[0]);
-        dalamudRenderer.Render(resources.DalamudRenderTarget.RenderTargetView);
+        dalamudRenderer.Render(
+            (ID3D11Texture2D*)resources.DalamudRenderTarget.Texture,
+            resources.DalamudRenderTarget.RenderTargetView
+        );
 
         RenderCursor(context, new Vector2D<float>(width, height));
     }


### PR DESCRIPTION
Updates DalamudRenderer to account for Dalamud's changes to RenderDrawDataInternal in Dx11Renderer seen [here](https://github.com/goatcorp/Dalamud/blob/5030f6885165df40a43139b3a9a1d1e8b2c321da/Dalamud/Interface/ImGuiBackend/Renderers/Dx11Renderer.cs#L249) Looks like this is also present in the [v15 api](https://github.com/goatcorp/Dalamud/blob/d6db9263441561d1b2552b1621d9345a34ebfd8d/Dalamud/Interface/ImGuiBackend/Renderers/Dx11Renderer.cs#L249) branch. Not sure when these changes happened, just barely decided to try ffxiv with VR and found this repo.

Let me know if I need any more changes, seems to work fine for me.

Closes #91 
Closes #93